### PR TITLE
feat: Divide color group by cosine similar

### DIFF
--- a/background.js
+++ b/background.js
@@ -24,68 +24,6 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   }
 });
 
-// function pickColorMode(imageSrc) {
-//   document.body.style.pointerEvents = "none";
-//   function rgbaToHex(r, g, b, a) {
-//     let hexCode = (value) => value.toString(16).padStart(2, "0");
-//     let alpha = a < 1 ? hexCode(Math.round(a * 255)) : "";
-//     return `#${hexCode(r)}${hexCode(g)}${hexCode(b)}${alpha}`.toUpperCase();
-//   }
-//   let img = new Image();
-//   img.src = imageSrc;
-
-//   img.onload = () => {
-//     // 🔹 캔버스를 생성하고, 캡처한 이미지를 그림
-//     let canvas = document.createElement("canvas");
-//     let ctx = canvas.getContext("2d");
-//     canvas.width = img.width;
-//     canvas.height = img.height;
-//     ctx.drawImage(img, 0, 0, img.width, img.height);
-
-//     document.addEventListener(
-//       "click",
-//       (event) => {
-//         let x = event.clientX;
-//         let y = event.clientY;
-
-//         let pixel = ctx.getImageData(x, y, 1, 1).data;
-//         let hexColor = rgbaToHex(pixel[0], pixel[1], pixel[2], pixel[3] / 255);
-
-//         console.log("선택한 색상:", hexColor);
-
-//         chrome.runtime.sendMessage({
-//           action: "openPopupWithColor",
-//           color: hexColor,
-//         });
-
-//         document.body.style.pointerEvents = "auto";
-//       },
-//       { once: true }
-//     ); // 한 번만 실행되도록 설정
-//   };
-// }
-
-// chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-//   if (message.action === "openPopupWithColor") {
-//     chrome.storage.local.set({ pickedColor: message.color }, () => {
-//       console.log("색상이 저장되었습니다:", message.color);
-
-//       chrome.windows.getCurrent((currentWindow) => {
-//         let windowWidth = currentWindow.width || 1920;
-//         let windowHeight = currentWindow.height || 1080;
-
-//         chrome.windows.create({
-//           url: "popup.html",
-//           type: "popup",
-//           width: 350,
-//           height: windowHeight,
-//           top: 0,
-//           left: windowWidth - 350,
-//         });
-//       });
-//     });
-//   }
-// });
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "captureScreen") {
     chrome.permissions.request({ permissions: ["tabs"] }, (granted) => {
@@ -132,19 +70,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
               });
             }
           );
-          // chrome.scripting.executeScript(
-          //   {
-          //     target: { tabId: activeTabId },
-          //     files: ["content.js"],
-          //   },
-          //   () => {
-          //     chrome.scripting.executeScript({
-          //       target: { tabId: activeTabId },
-          //       func: () => window.extractColorsFromImage(),
-          //       args: [imageSrc, x1, y1, x2, y2],
-          //     });
-          //   }
-          // );
 
           sendResponse({ success: true, image: imageSrc });
         });

--- a/popup.js
+++ b/popup.js
@@ -14,19 +14,19 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     if (data.extractedColors && data.extractedColors.length > 0) {
-      let { grayscaleColors, colorClusters } = separateGrayscale(
-        data.extractedColors,
-        5
-      );
+      let { grayscaleColors, colorClusters } =
+        separateGrayscaleAndGroupByCosine(data.extractedColors, 0.99); // ✅ 더 엄격한 유사도 적용
 
-      // ✅ 흑백 계열 색상 표시
+      // ✅ 흑백 계열 색상 표시 (정렬 적용)
       if (grayscaleColors.length > 0) {
+        grayscaleColors.sort(); // ✅ 오름차순 정렬
         createColorGroup("흑백 계열", grayscaleColors, colorContainer);
       }
 
       // ✅ 컬러 그룹 표시
       colorClusters.forEach((group, index) => {
-        createColorGroup(`컬러 그룹 ${index + 1}`, group, colorContainer);
+        group.sort(); // ✅ 그룹 내 색상 오름차순 정렬
+        createColorGroup(`색상 그룹 ${index + 1}`, group, colorContainer);
       });
     } else {
       colorContainer.innerText = "추출된 색상 없음";
@@ -34,8 +34,8 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 });
 
-// ✅ 흑백 계열 색상과 컬러 색상을 분리하는 함수
-function separateGrayscale(colors, numClusters) {
+// ✅ 더욱 정밀한 흑백 계열 분리 및 코사인 유사도로 그룹화
+function separateGrayscaleAndGroupByCosine(colors, similarityThreshold = 0.98) {
   let grayscaleColors = [];
   let colorColors = [];
 
@@ -43,18 +43,98 @@ function separateGrayscale(colors, numClusters) {
     let rgb = hexToRgb(hex);
     let hsl = rgbToHsl(rgb);
 
-    // ✅ 흑백 계열 (채도(S)가 10% 이하)
-    if (hsl[1] <= 0.1) {
+    // ✅ 채도(S) ≤ 0.2이면 회색 계열도 포함하여 흑백 계열로 분류
+    if (hsl[1] <= 0.2) {
       grayscaleColors.push(hex);
     } else {
       colorColors.push(hex);
     }
   });
 
-  // ✅ 흑백 계열을 따로 저장하고, 컬러만 K-Means 클러스터링 수행
-  let colorClusters = clusterColors(colorColors, numClusters);
+  // ✅ 컬러만 코사인 유사성으로 그룹화
+  let colorClusters = groupByCosineSimilarity(colorColors, similarityThreshold);
 
   return { grayscaleColors, colorClusters };
+}
+
+// ✅ 코사인 유사도를 기반으로 색상 그룹화
+function groupByCosineSimilarity(colors, similarityThreshold = 0.98) {
+  let rgbColors = colors.map(hexToRgb);
+  let clusters = [];
+
+  while (rgbColors.length > 0) {
+    let baseColor = rgbColors.shift();
+    let baseHex = rgbToHex(baseColor);
+    let cluster = [baseHex];
+
+    rgbColors = rgbColors.filter((color) => {
+      let similarity = cosineSimilarity(baseColor, color);
+      if (similarity > similarityThreshold) {
+        // ✅ 유사도 0.98 이상인 색상만 같은 그룹으로
+        cluster.push(rgbToHex(color));
+        return false;
+      }
+      return true;
+    });
+
+    clusters.push(cluster);
+  }
+
+  return clusters.filter((cluster) => cluster.length > 0);
+}
+
+// ✅ 코사인 유사도 계산
+function cosineSimilarity(rgb1, rgb2) {
+  let dotProduct = rgb1[0] * rgb2[0] + rgb1[1] * rgb2[1] + rgb1[2] * rgb2[2];
+  let magnitude1 = Math.sqrt(rgb1[0] ** 2 + rgb1[1] ** 2 + rgb1[2] ** 2);
+  let magnitude2 = Math.sqrt(rgb2[0] ** 2 + rgb2[1] ** 2 + rgb2[2] ** 2);
+  return dotProduct / (magnitude1 * magnitude2);
+}
+
+// ✅ HEX → RGB 변환
+function hexToRgb(hex) {
+  hex = hex.replace(/^#/, "");
+  let bigint = parseInt(hex, 16);
+  return [(bigint >> 16) & 255, (bigint >> 8) & 255, bigint & 255];
+}
+
+// ✅ RGB → HEX 변환
+function rgbToHex(rgb) {
+  return `#${rgb.map((v) => v.toString(16).padStart(2, "0")).join("")}`;
+}
+
+// ✅ RGB → HSL 변환 (흑백 계열 판별에 사용)
+function rgbToHsl([r, g, b]) {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  let max = Math.max(r, g, b);
+  let min = Math.min(r, g, b);
+  let h,
+    s,
+    l = (max + min) / 2;
+
+  if (max === min) {
+    h = s = 0; // 무채색
+  } else {
+    let d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return [h, s, l];
 }
 
 // ✅ 색상 그룹을 생성하는 함수 (UI 업데이트)
@@ -116,112 +196,4 @@ function createColorGroup(title, colors, container) {
 
   groupContainer.appendChild(colorListContainer);
   container.appendChild(groupContainer);
-}
-
-// ✅ 그룹의 대표 색상(평균값) 계산
-function calculateAverageColor(colorGroup) {
-  let rgbColors = colorGroup.map(hexToRgb);
-  let avgColor = rgbColors.reduce(
-    (acc, val) => acc.map((v, i) => v + val[i]),
-    [0, 0, 0]
-  );
-  avgColor = avgColor.map((v) => Math.round(v / colorGroup.length));
-  return rgbToHex(avgColor);
-}
-
-// ✅ 색상을 비슷한 그룹으로 클러스터링 (K-Means 방식)
-function clusterColors(colors, numClusters) {
-  let rgbColors = colors.map(hexToRgb);
-  let clusters = kMeans(rgbColors, numClusters);
-  return clusters.map((cluster) => cluster.map(rgbToHex));
-}
-
-// ✅ HEX → RGB 변환
-function hexToRgb(hex) {
-  hex = hex.replace(/^#/, "");
-  let bigint = parseInt(hex, 16);
-  return [(bigint >> 16) & 255, (bigint >> 8) & 255, bigint & 255];
-}
-
-// ✅ RGB → HEX 변환
-function rgbToHex(rgb) {
-  return `#${rgb.map((v) => v.toString(16).padStart(2, "0")).join("")}`;
-}
-
-// ✅ RGB → HSL 변환
-function rgbToHsl([r, g, b]) {
-  r /= 255;
-  g /= 255;
-  b /= 255;
-
-  let max = Math.max(r, g, b);
-  let min = Math.min(r, g, b);
-  let h,
-    s,
-    l = (max + min) / 2;
-
-  if (max === min) {
-    h = s = 0; // 무채색
-  } else {
-    let d = max - min;
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    switch (max) {
-      case r:
-        h = (g - b) / d + (g < b ? 6 : 0);
-        break;
-      case g:
-        h = (b - r) / d + 2;
-        break;
-      case b:
-        h = (r - g) / d + 4;
-        break;
-    }
-    h /= 6;
-  }
-
-  return [h, s, l];
-}
-
-// ✅ K-Means 클러스터링 알고리즘
-function kMeans(data, k) {
-  let centroids = data.slice(0, k); // 초기 중심점 선택
-  let prevCentroids = [];
-  let clusters = new Array(k).fill().map(() => []);
-
-  while (!arraysEqual(centroids, prevCentroids)) {
-    clusters = new Array(k).fill().map(() => []);
-
-    // ✅ 각 데이터 포인트를 가장 가까운 중심점에 할당
-    data.forEach((point) => {
-      let distances = centroids.map((centroid) =>
-        euclideanDistance(point, centroid)
-      );
-      let clusterIndex = distances.indexOf(Math.min(...distances));
-      clusters[clusterIndex].push(point);
-    });
-
-    prevCentroids = centroids;
-    centroids = clusters.map((cluster) => calculateCentroid(cluster));
-  }
-
-  return clusters;
-}
-
-// ✅ 유클리드 거리 계산
-function euclideanDistance(p1, p2) {
-  return Math.sqrt(
-    p1.reduce((sum, value, index) => sum + (value - p2[index]) ** 2, 0)
-  );
-}
-
-// ✅ 클러스터 중심 계산
-function calculateCentroid(cluster) {
-  if (cluster.length === 0) return [0, 0, 0];
-  let sum = cluster.reduce((acc, val) => acc.map((v, i) => v + val[i]));
-  return sum.map((v) => Math.round(v / cluster.length));
-}
-
-// ✅ 두 배열이 같은지 비교
-function arraysEqual(a, b) {
-  return JSON.stringify(a) === JSON.stringify(b);
 }


### PR DESCRIPTION
- 기존 k-means 방식으로 색상 그룹화 -> cosine 유사도를 바탕으로 색상 그룹화로 변경
- 유사도 판별기준을 0.99로 설정
- 흑백 계열 분리를 위한 채도 기준을 0.2로 상향 및 명도 기준 추가