### PR TITLE
feat: Divide popup page to show preset page and extract color page

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,20 @@
+chrome.action.onClicked.addListener(() => {
+  chrome.action.setPopup({ popup: "popup_default.html" });
+});
+
+// chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+//   if (message.action === "openColorPopup") {
+//     chrome.storage.local.set({ popupMode: "colorPicker" }, () => {
+//       chrome.windows.create({
+//         url: "popup.html",
+//         type: "popup",
+//         width: 350,
+//         height: 600,
+//       });
+//     });
+//   }
+// });
+
 // 확장 프로그램의 백그라운드 동작 구현
 chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
@@ -83,7 +100,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "saveExtractedColors") {
     chrome.storage.local.set(
-      { extractedColors: message.colors, capturedImage: message.image },
+      {
+        extractedColors: message.colors,
+        capturedImage: message.image,
+        popupMode: "colorPicker",
+      },
       () => {
         console.log("✅ 색상 데이터 저장 완료");
 
@@ -105,5 +126,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     );
 
     return true; // ✅ 비동기 응답을 사용하기 위해 `return true;` 필요
+  } else if (message.action === "updatePresets") {
+    chrome.storage.local.get(["colorPresets"], (data) => {
+      sendResponse({ presets: data.colorPresets });
+    });
+    return true; // 비동기 응답을 위해 true 반환
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
     "service_worker": "background.js"
   },
   "action": {
-    "default_popup": "popup.html"
+    "default_popup": "popup_default.html"
   },
   "permissions": ["activeTab", "contextMenus", "scripting", "tabs", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/popup.js
+++ b/popup.js
@@ -2,7 +2,6 @@ document.addEventListener("DOMContentLoaded", () => {
   chrome.storage.local.get(["capturedImage", "extractedColors"], (data) => {
     let imageContainer = document.getElementById("capturedImageContainer");
     let colorContainer = document.getElementById("colorList");
-    let presetContainer = document.getElementById("presetList");
 
     if (data.capturedImage) {
       let img = new Image();
@@ -54,7 +53,13 @@ function addColorToPreset(color) {
 
       presets.push(newPreset);
       chrome.storage.local.set({ colorPresets: presets }, () => {
+        console.log("✅ 프리셋 저장 완료:", presets);
         updatePresetList(presets);
+
+        // ✅ popup_default.html에 업데이트 메시지 전송
+        chrome.runtime.sendMessage({ action: "updatePresets" }, (response) => {
+          console.log("📢 프리셋 업데이트 메시지 전송 완료:", response);
+        });
       });
     }
   });
@@ -87,13 +92,6 @@ function updatePresetList(presets) {
     presetContainer.appendChild(presetDiv);
   });
 }
-
-// // ✅ 프리셋 적용 (저장된 색상을 UI에 표시)
-// function loadPreset(colors) {
-//   let colorContainer = document.getElementById("colorList");
-//   colorContainer.innerHTML = "";
-//   createColorGroup("적용된 프리셋", colors, colorContainer);
-// }
 
 // ✅ 프리셋에서 개별 색상 삭제
 function deletePreset(color) {

--- a/popup_default.html
+++ b/popup_default.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <title>색상 프리셋</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        padding: 10px;
+        width: 300px;
+      }
+      .preset-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        margin-bottom: 10px;
+      }
+      .color-information {
+        display: flex;
+        align-items: center;
+      }
+      .color-box {
+        width: 40px;
+        height: 40px;
+        display: inline-block;
+        border-radius: 5px;
+        border: 1px solid #ddd;
+        margin-right: 5px;
+      }
+      .hex-text {
+        font-size: 14px;
+        font-weight: bold;
+      }
+      button {
+        background-color: #007bff;
+        color: white;
+        border: none;
+        padding: 5px 10px;
+        cursor: pointer;
+        border-radius: 5px;
+      }
+      button:hover {
+        background-color: #0056b3;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>저장된 프리셋</h2>
+    <div id="presetList"></div>
+    <script src="popup_default.js"></script>
+  </body>
+</html>

--- a/popup_default.js
+++ b/popup_default.js
@@ -1,0 +1,58 @@
+document.addEventListener("DOMContentLoaded", () => {
+  loadPresets();
+});
+
+// ✅ `chrome.storage.onChanged` 리스너 추가 (자동 업데이트)
+chrome.storage.onChanged.addListener((changes, namespace) => {
+  if (changes.colorPresets) {
+    console.log("📢 프리셋 변경 감지, 업데이트 수행");
+    loadPresets();
+  }
+});
+
+function loadPresets() {
+  chrome.storage.local.get(["colorPresets"], (data) => {
+    let presetContainer = document.getElementById("presetList");
+    presetContainer.innerHTML = "";
+
+    if (data.colorPresets && data.colorPresets.length > 0) {
+      data.colorPresets.forEach((color) => {
+        let presetDiv = document.createElement("div");
+        presetDiv.classList.add("preset-item");
+
+        let colorInformationBox = document.createElement("div");
+        colorInformationBox.classList.add("color-information");
+
+        let colorBox = document.createElement("div");
+        colorBox.classList.add("color-box");
+        colorBox.style.backgroundColor = color.color;
+
+        let hexText = document.createElement("span");
+        hexText.classList.add("hex-text");
+        hexText.innerText = color.hexCode;
+
+        let deleteBtn = document.createElement("button");
+        deleteBtn.innerText = "삭제";
+        deleteBtn.onclick = () => deletePreset(color.color);
+
+        presetDiv.appendChild(colorInformationBox);
+        colorInformationBox.appendChild(colorBox);
+        colorInformationBox.appendChild(hexText);
+        presetDiv.appendChild(deleteBtn);
+        presetContainer.appendChild(presetDiv);
+      });
+    } else {
+      presetContainer.innerHTML = "<p>저장된 프리셋이 없습니다.</p>";
+    }
+  });
+}
+
+function deletePreset(color) {
+  chrome.storage.local.get("colorPresets", (data) => {
+    let presets = data.colorPresets || [];
+    let updatedPresets = presets.filter((c) => c.color !== color);
+    chrome.storage.local.set({ colorPresets: updatedPresets }, () => {
+      loadPresets();
+    });
+  });
+}


### PR DESCRIPTION
- 기존 popup.html을 popup_default.html와 popup.html로 분화
- popup.html는 기존처럼 색 추출 후 나오는 popup
- popup_default.html는 아이콘 클릭 시 저장된 preset을 보여주는 popup
- popup.html에서 색상을 프리셋에 넣어 저장하면, popup_default.html에서 저장된 색상 확인 가능
- popup_default.html UI 조정