### PR TITLE
feat: Fix UI error in popup_default.html

### DIFF
--- a/popup_default.html
+++ b/popup_default.html
@@ -288,6 +288,15 @@
         border-radius: 5px;
       }
 
+      .dark-mode .detail-footer-button {
+        background: #444;
+        color: white;
+      }
+
+      .dark-mode .detail-footer-button:hover {
+        background: #666;
+      }
+
       .dark-mode-footer {
         background-color: #333 !important;
         color: white !important;
@@ -385,7 +394,7 @@
     </div>
 
     <div id="navBarDetail" class="navBar hidden">
-      <button id="backToMainPage">←</button>
+      <button id="backToMainPage" class="back-btn">←</button>
       <span id="presetDetailTitle">프리셋 상세</span>
       <div class="empty"></div>
     </div>
@@ -396,8 +405,12 @@
 
       <!-- ✅ 하단 버튼 컨테이너 -->
       <div class="detail-buttons" id="presetDetailFooter">
-        <button id="toggleEditMode">편집하기</button>
-        <button id="sendToCode">코드로 보내기</button>
+        <button id="toggleEditMode" class="detail-footer-button">
+          편집하기
+        </button>
+        <button id="sendToCode" class="detail-footer-button">
+          코드로 보내기
+        </button>
       </div>
     </div>
 

--- a/popup_default.js
+++ b/popup_default.js
@@ -75,6 +75,46 @@ document.addEventListener("DOMContentLoaded", () => {
     // ✅ 다크모드 스타일 적용
     applyDarkMode();
   });
+
+  const nameOnlyInput = document.getElementById("newPresetName");
+  const nameOnlyInputSave = document.getElementById("savePreset");
+  const codeNameInput = document.getElementById("importPresetName");
+  const codeTextInput = document.getElementById("encryptedCodeInput");
+  const codeTextInputSave = document.getElementById("decodeAndSave");
+
+  function updateInputStates() {
+    if (nameOnlyInput.value.trim() !== "") {
+      codeNameInput.disabled = true;
+      codeTextInput.disabled = true;
+      codeTextInputSave.disabled = true;
+    } else if (
+      codeNameInput.value.trim() !== "" ||
+      codeTextInput.value.trim() !== ""
+    ) {
+      nameOnlyInput.disabled = true;
+      nameOnlyInputSave.disabled = true;
+    } else {
+      // 모두 비어 있으면 다시 활성화
+      nameOnlyInput.disabled = false;
+      nameOnlyInputSave.disabled = false;
+      codeNameInput.disabled = false;
+      codeTextInput.disabled = false;
+      codeTextInputSave.disabled = false;
+    }
+  }
+
+  nameOnlyInput.addEventListener("input", updateInputStates);
+  codeNameInput.addEventListener("input", updateInputStates);
+  codeTextInput.addEventListener("input", updateInputStates);
+
+  // 저장 후 모든 입력 활성화 복구
+  document.getElementById("savePreset").addEventListener("click", () => {
+    setTimeout(() => updateInputStates(), 100); // 잠시 후 상태 재확인
+  });
+
+  document.getElementById("decodeAndSave").addEventListener("click", () => {
+    setTimeout(() => updateInputStates(), 100);
+  });
 });
 
 let selectedPresetIndex = null;
@@ -328,7 +368,7 @@ function showPresetDetails(presetIndex) {
 
     document.getElementById("presetList").classList.add("hidden");
     document.getElementById("presetDetails").classList.remove("hidden");
-    document.getElementById("toggleEditMode").innerText = "이름 변경"; // ✅ 초기 버튼 상태
+    document.getElementById("toggleEditMode").innerText = "편집하기"; // ✅ 초기 버튼 상태
     isEditing = false;
   });
 }


### PR DESCRIPTION
- popup_default.html의 일반 모드 화면 상태에서 상세보기의 뒤로가기 버튼이 안보이는 현상 수정
- popup_default.html의 다크모드 상세보기 화면 하단 버튼들이 다크모드가 적용되지 않는 현산 수정
- 새 프리셋 생성 화면에서 하나의 input이 빈칸이 아니면 다른 방법의 input은 비활성화되도록 수정